### PR TITLE
Add gha-s3-pg-helper image, gha and readme.

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,5 @@
+self-hosted-runner:
+  # Labels of self-hosted runner in array of string
+  labels:
+  - small
+  - large

--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         image:
-        - gha-s2-pg-helper
+        - gha-s3-pg-helper
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -45,7 +45,7 @@ jobs:
     - name: Build and Publish to DockerHub
       uses: docker/build-push-action@v3
       with:
-        context: ${{ matrix.image }}/
+        context: ./${{ matrix.image }}/
         # Don't push on pull_request, just build and check for errors
         push: ${{ github.event_name == 'pull_request' && 'false' || 'true' }}
         tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -1,0 +1,51 @@
+# Copyright (c) 2022 MobileCoin Inc.
+name: build-and-publish
+
+on:
+  push:
+    tags:
+    - 'v*.*.*'
+  pull_request: {}
+
+env:
+  DOCKER_ORG: mobilecoin
+
+jobs:
+  docker:
+    runs-on: [self-hosted, Linux, small]
+    strategy:
+      matrix:
+        image:
+        - gha-s2-pg-helper
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Generate Docker Tags
+      id: meta
+      uses: docker/metadata-action@v4
+      with:
+        images: ${{ env.DOCKER_ORG }}/${{ matrix.image }}
+        tags: |
+          type=ref,event=pr,priority=30
+          type=semver,pattern=v{{major}},priority=22
+          type=semver,pattern=v{{major}}.{{minor}},priority=21
+          type=semver,pattern=v{{version}},priority=20
+          type=sha,priority=10
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Login to DockerHub
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+    - name: Build and Publish to DockerHub
+      uses: docker/build-push-action@v3
+      with:
+        context: ${{ matrix.image }}/
+        # Don't push on pull_request, just build and check for errors
+        push: ${{ github.event_name == 'pull_request' && 'false' || 'true' }}
+        tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,21 @@
+# Copyright (c) 2022 MobileCoin Inc.
+name: release
+
+on:
+  push:
+    tags:
+    - 'v*.*.*'
+
+permissions:
+  contents: write
+
+jobs:
+  gh-release:
+    runs-on: [self-hosted, Linux, small]
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Create a GitHub Release
+      uses: softprops/action-gh-release@v1
+      with:
+        generate_release_notes: true

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -4,7 +4,10 @@ name: tag
 on:
   push:
     branches:
-      - main
+    - main
+  # Refresh images on the first of every month to update OS dependencies.
+  schedule:
+  - cron: '0 0 1 * *'
 
 jobs:
   tag:

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
     - main
-  # Refresh images on the first of every month to update OS dependencies.
+  # Refresh images on the first of every month for OS security updates.
   schedule:
   - cron: '0 0 1 * *'
 

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -1,0 +1,39 @@
+# Copyright (c) 2022 MobileCoin Inc.
+name: tag
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  tag:
+    runs-on: [self-hosted, Linux, small]
+    steps:
+    # We need to use an external PAT here because GHA will not run downstream events if we use the built in token.
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        token: ${{ secrets.ACTIONS_TOKEN }}
+
+    - name: Bump GitHub tag
+      id: bump
+      uses: anothrNick/github-tag-action@1.36.0
+      env:
+        GITHUB_TOKEN: ${{ secrets.ACTIONS_TOKEN }}
+        WITH_V: 'true'
+        DEFAULT_BUMP: patch
+        DRY_RUN: 'true'
+
+    # Doing manual tags because anothrNick/github-tag-action won't retag a commit.
+    - name: Get major and minor values for new tag
+      id: tags
+      env:
+        TAG: ${{ steps.bump.outputs.new_tag }}
+      run: |
+        export MAJOR_MINOR=${TAG%.*}
+        export MAJOR=${MAJOR_MINOR%.*}
+        git tag --force "${MAJOR}"
+        git tag --force "${MAJOR_MINOR}"
+        git tag --force "${TAG}"
+        git push --tags --force

--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
 # gha-docker-helpers
-Assortment of docker containers for use in GHA workflows.
+Assortment of docker utility containers for use in MobileCoin GHA workflows.
+
+### How to add an image to this set.
+
+1. Create a directory in the root of the repo with the name of the image you want to build.
+1. Place a `Dockerfile` in the directory.
+1. Add any additional support files, scripts you need.
+1. Add a entry in the `.github/workflows/build-and-publish.yaml` `image` matrix matching the name of the directory.
+
+The GHA automation will use the image directory for docker build context.
+
+### Workflow and automation.
+
+1. PR changes to `main`
+1. Merge changes to `main` after approvals.
+1. On merge to main GHA will automatically create a series for semver git tags bumping the `patch` by default (`v1`, `v1.0`, `v1.0.0`).
+1. On `v*.*.*` tag GHA will automatically create a GH Release with automatic release notes.
+1. On `v*.*.*` tag GHA will automatically build docker images with the semver series of tags (`v1`, `v1.0`, `v1.0.0`).
+
+### Bump major/minor tags.
+
+Add `#major`, `#minor` to the commit message to create major/minor releases.

--- a/gha-s3-pg-helper/Dockerfile
+++ b/gha-s3-pg-helper/Dockerfile
@@ -1,0 +1,21 @@
+# Copyright (c) 2022 MobileCoin Inc.
+#
+# A small utility container to restore a db from an s3 backup.
+
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=Etc/UTC
+
+RUN  apt-get update \
+  && apt-get upgrade -y \
+  && apt-get install -y \
+      ca-certificates \
+      curl \
+      bash \
+      postgresql-client \
+      awscli \
+  && apt-get clean \
+  && rm -r /var/lib/apt/lists
+
+CMD ["psql", "--help"]


### PR DESCRIPTION
Repo for the random small helper images for GHA automation. A junk drawer to make it easy to add containers we could use until we need to separate them out for their own lifecycle.

- Set up auto-tag/release/build...
- Add Readme
- Add `gha-s3-pg-helper` image.
- Add cron to refresh images for OS security updates on the first of every month.
